### PR TITLE
fix an ESLint checking error caused by the AWS generated file

### DIFF
--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -92,7 +92,8 @@ module.exports = function (ctx) {
             enforce: 'pre',
             test: /\.(js|vue)$/,
             loader: 'eslint-loader',
-            exclude: /node_modules/,
+            // exclude: /node_modules/,
+            exclude: /(node_modules|src\/aws\-exports\.js)/,
             options: {
               formatter: require('eslint').CLIEngine.getFormatter('stylish')
             },


### PR DESCRIPTION
Fixed an ESLint error caused by an AWS generated file.
This issue blocked the CI deployment process.